### PR TITLE
Add vcpkg manifest file

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "coder2k-engine2d",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "glad",
+    "glfw3",
+    "tbb",
+    "ms-gsl",
+    "tl-expected",
+    "tl-optional",
+    "spdlog",
+    "nlohmann-json",
+    "range-v3",
+    "glm",
+    "boost",
+    "lua",
+    "sol2",
+    "magic-enum",
+    {
+      "name": "imgui",
+      "features": [
+        "docking-experimental",
+        "glfw-binding",
+        "opengl3-binding"
+      ]
+    },
+    "tinyfiledialogs",
+    "stb"
+  ]
+}


### PR DESCRIPTION
Original dump from https://pastebin.com/18XMxv7L

Additionally added `tbb` package and changed the names to only contain lower case
alphanumeric characters and hyphens as requested by the documentation
https://github.com/microsoft/vcpkg/blob/master/docs/users/manifests.md

The following commands worked for me:

```sh
cmake -S -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
cmake --build build --target Viped -j4
```

Replace VCPKG_ROOT with a value suitable for your installation.
For me VCPKG_ROOT is `/opt/vcpkg` resulting in the full path:
`-DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake`.

edit: `vcpkg install` isn't needed, done automatically by just defining the toolchain file